### PR TITLE
Enable custom context directory for loader

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,13 @@
+## EnhancedRAG Documentation
+
+### Configurable Context Directory
+
+`DocumentLoader` now accepts an optional path when instantiated:
+
+```python
+loader = DocumentLoader(base_context_dir="/path/to/my/docs")
+```
+
+If no directory is provided, it defaults to `settings.CONTEXT_DIR`, which is
+read from `.env`. This change allows the ingestion and generation pipelines to
+operate on any valid directory without breaking existing behaviour.

--- a/src/ingestion/DocumentLoader.py
+++ b/src/ingestion/DocumentLoader.py
@@ -22,21 +22,28 @@ logger.setLevel(logging.INFO)
 
 class DocumentLoader:
     """
-    Handles discovery and loading of documents from a centralized context directory.
+    Handles discovery and loading of documents from a base context directory.
 
     Uses langchain_community loaders under the hood and tracks:
       - Number of inputs/outputs via metrics decorator.
       - Errors via structured logging.
 
     Attributes:
-        base_context_dir (Path): Root directory under which all subdirs reside.
+        base_context_dir (Path):
+            Root directory containing the documents. Defaults to
+            ``settings.CONTEXT_DIR`` if not specified when constructing
+            the loader.
     """
 
-    def __init__(self):
+    def __init__(self, base_context_dir: Optional[str | Path] = None):
         """
-        Initialize the loader, setting base_context_dir from settings.CONTEXT_DIR.
+        Initialize the loader with an optional base context directory.
+
+        Args:
+            base_context_dir: Directory containing the source documents. If
+                ``None`` (default), ``settings.CONTEXT_DIR`` is used.
         """
-        self.base_context_dir = Path(settings.CONTEXT_DIR)
+        self.base_context_dir = Path(base_context_dir or settings.CONTEXT_DIR)
 
     @track_metrics(lambda filenames: len(filenames), target="outputs")
     def list_filenames(


### PR DESCRIPTION
## Summary
- allow `DocumentLoader` to accept a `base_context_dir` argument
- document configurable context directory in docs

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844091c4040832f887d7a027052d75c